### PR TITLE
Replace norm_func with norm_mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.4.0
+Version: 0.5.0
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -20,8 +20,8 @@
 #' @param y BigWig file corresponding to the y axis.
 #' @param bg_x BigWig file to be used as x axis background (us. input).
 #' @param bg_y BigWig file to be used as y axis background (us. input).
-#' @param norm_func_x Function to use after x / x_bg.
-#' @param norm_func_y Function to use after y / y_bg.
+#' @param norm_mode_x Normalization mode for x axis.
+#' @param norm_mode_y Normalization mode for y axis.
 #' @param highlight List of bed files to use as highlight for subgroups.
 #' @param minoverlap Minimum overlap required for a bin to be highlighted
 #' @param highlight_label Labels for the highlight groups.
@@ -34,8 +34,8 @@
 #' @export
 plot_bw_bins_scatter <- function(x, y,
                                  bg_x = NULL, bg_y = NULL,
-                                 norm_func_x = identity,
-                                 norm_func_y = identity,
+                                 norm_mode_x = "fc",
+                                 norm_mode_y = "fc",
                                  bin_size = 10000,
                                  genome = "mm9",
                                  highlight = NULL,
@@ -45,11 +45,12 @@ plot_bw_bins_scatter <- function(x, y,
                                  remove_top = 0,
                                  verbose = TRUE) {
 
+
   bins_values_x <- bw_bins(x,
                            bg_bwfiles = bg_x,
                            bin_size = bin_size,
                            genome = genome,
-                           norm_func = norm_func_x,
+                           norm_mode = norm_mode_x,
                            labels = "x"
   )
 
@@ -57,17 +58,17 @@ plot_bw_bins_scatter <- function(x, y,
                            bg_bwfiles = bg_y,
                            bin_size = bin_size,
                            genome = genome,
-                           norm_func = norm_func_y,
+                           norm_mode = norm_mode_y,
                            labels = "y"
   )
 
   highlight_data <- process_highlight_loci(highlight, highlight_label)
 
   x_label <- paste(make_label_from_filename(x), "-",
-                   make_norm_label(substitute(norm_func_x), bg_x))
+                   make_norm_label(norm_mode_x, bg_x))
 
   y_label <- paste(make_label_from_filename(y), "-",
-                   make_norm_label(substitute(norm_func_y), bg_y))
+                   make_norm_label(norm_mode_y, bg_y))
 
   plot_results <- plot_ranges_scatter(bins_values_x, bins_values_y,
          highlight = highlight_data$ranges,
@@ -122,7 +123,7 @@ plot_bw_bins_violin <- function(bwfiles,
                                 genome = "mm9",
                                 highlight = NULL,
                                 minoverlap = 0L,
-                                norm_func = identity,
+                                norm_mode = "fc",
                                 highlight_label = NULL,
                                 highlight_colors = NULL,
                                 remove_top = 0,
@@ -134,7 +135,7 @@ plot_bw_bins_violin <- function(bwfiles,
                          bin_size = bin_size,
                          genome = genome,
                          per_locus_stat = per_locus_stat,
-                         norm_func = norm_func,
+                         norm_mode = norm_mode,
                          remove_top = 0)
 
 
@@ -186,7 +187,7 @@ plot_bw_bins_violin <- function(bwfiles,
 
   }
 
-  y_label <- make_norm_label(substitute(norm_func), bg_bwfiles)
+  y_label <- make_norm_label(norm_mode, bg_bwfiles)
 
   plot <- ggplot(melted_bins, aes_string(x = "variable", y = "value")) +
     geom_violin(fill = "#cccccc") +
@@ -241,10 +242,10 @@ plot_bw_bins_violin <- function(bwfiles,
 #' @param x BigWig file corresponding to the x axis.
 #' @param y BigWig file corresponding to the y axis.
 #' @param loci Bed file or GRanges object to be plotted.
+#' @param norm_mode_x Normalization mode for x axis.
+#' @param norm_mode_y Normalization mode for y axis.
 #' @param bg_x BigWig file to be used as x axis background (us. input).
 #' @param bg_y BigWig file to be used as y axis background (us. input).
-#' @param norm_func_x Function to use after x / x_bg.
-#' @param norm_func_y Function to use after y / y_bg.
 #' @param highlight List of bed files to use as highlight for subgroups.
 #' @param minoverlap Minimum overlap required for a bin to be highlighted
 #' @param highlight_label Labels for the highlight groups.
@@ -260,8 +261,8 @@ plot_bw_bins_violin <- function(bwfiles,
 plot_bw_loci_scatter <- function(x, y,
                                  loci,
                                  bg_x = NULL, bg_y = NULL,
-                                 norm_func_x = identity,
-                                 norm_func_y = identity,
+                                 norm_mode_x = "fc",
+                                 norm_mode_y = "fc",
                                  highlight = NULL,
                                  minoverlap = 0L,
                                  highlight_label = NULL,
@@ -270,22 +271,22 @@ plot_bw_loci_scatter <- function(x, y,
                                  verbose = TRUE) {
 
   values_x <- bw_bed(x, bg_bwfiles = bg_x, bedfile = loci,
-                     norm_func = norm_func_x,
+                     norm_mode = norm_mode_x,
                      labels = "x"
               )
 
   values_y <- bw_bed(y, bg_bwfiles = bg_y, bedfile = loci,
-                     norm_func = norm_func_y,
+                     norm_mode = norm_mode_y,
                      labels = "y"
               )
 
   highlight_data <- process_highlight_loci(highlight, highlight_label)
 
   x_label <- paste(make_label_from_filename(x), "-",
-                   make_norm_label(substitute(norm_func_x), bg_x))
+                   make_norm_label(norm_mode_x, bg_x))
 
   y_label <- paste(make_label_from_filename(y), "-",
-                   make_norm_label(substitute(norm_func_y), bg_y))
+                   make_norm_label(norm_mode_y, bg_y))
 
   plot_results <- plot_ranges_scatter(values_x, values_y,
                                       highlight = highlight_data$ranges,
@@ -338,14 +339,14 @@ plot_bw_loci_summary_heatmap <- function(bwfiles,
                                          bg_bwfiles = NULL,
                                          labels = NULL,
                                          aggregate_by = "true_mean",
-                                         norm_func = identity,
+                                         norm_mode = "fc",
                                          remove_top = 0,
                                          verbose = TRUE) {
 
   summary_values <- bw_bed(bwfiles, loci,
                            bg_bwfiles = bg_bwfiles,
                            aggregate_by = aggregate_by,
-                           norm_func = norm_func,
+                           norm_mode = norm_mode,
                            labels = labels,
                            remove_top = remove_top
   )
@@ -357,7 +358,7 @@ plot_bw_loci_summary_heatmap <- function(bwfiles,
 
 
 
-  legend_label = make_norm_label(substitute(norm_func), bg_bwfiles)
+  legend_label = make_norm_label(norm_mode, bg_bwfiles)
   colorscale <- scale_fill_gradient(name=legend_label, low = "white", high="#B22222")
   if (!is.null(bg_bwfiles)) {
     colorscale <- scale_fill_gradient2(name=legend_label, low = "#2e6694", mid="white", high="#B22222")
@@ -366,8 +367,7 @@ plot_bw_loci_summary_heatmap <- function(bwfiles,
   summary_values$type <- rownames(summary_values)
   vals_melted <- reshape2::melt(summary_values, id.vars="type")
 
-  title <- paste("Coverage per region (", aggregate_by, ")")
-  title <- paste(title, "-", make_norm_label(substitute(norm_func), bg_bwfiles))
+  title <- paste("Coverage per region (", aggregate_by, ") - ", legend_label)
 
   plot <- ggplot(vals_melted, aes_string("type", "variable", fill="value")) +
     geom_tile() + geom_text(aes(label=round(value, 2)), size=3.5) +
@@ -549,11 +549,10 @@ make_caption <- function(params, outcome) {
 make_norm_label <- function(f, bg) {
   label <- "RPGC"
   if (!is.null(bg)) {
-    if (f != "identity") {
-      label <- paste(f, "(", label, " / background)", sep = "")
-    } else {
-      label <- paste(label, " / background", sep = "")
-    }
+    label = switch(f,
+                   "fc" = paste(label, " / background", sep = ""),
+                   "log2fc" = paste("log2(", label, " / background", sep = "")
+            )
   }
   label
 }

--- a/man/bw_bed.Rd
+++ b/man/bw_bed.Rd
@@ -11,7 +11,7 @@ bw_bed(
   labels = NULL,
   per_locus_stat = "mean",
   aggregate_by = NULL,
-  norm_func = identity,
+  norm_mode = "fc",
   remove_top = 0
 )
 }
@@ -32,7 +32,8 @@ Choices: min, max, sd, mean.}
 \item{aggregate_by}{Statistic to aggregate per group. If NULL, values are
 not aggregated. This is the behavior by default.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/man/bw_bins.Rd
+++ b/man/bw_bins.Rd
@@ -12,7 +12,7 @@ bw_bins(
   bin_size = 10000,
   genome = "mm9",
   selection = NULL,
-  norm_func = identity,
+  norm_mode = "fc",
   remove_top = 0
 )
 }
@@ -36,7 +36,8 @@ Choices: min, max, sd, mean.}
 intervals. This is useful for debugging and improving performance of
 locus specific analyses.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/man/bw_heatmap.Rd
+++ b/man/bw_heatmap.Rd
@@ -15,7 +15,7 @@ bw_heatmap(
   downstream = 2500,
   middle = NULL,
   ignore_strand = FALSE,
-  norm_func = identity
+  norm_mode = "fc"
 )
 }
 \arguments{
@@ -51,7 +51,8 @@ mode). If not provided, median length of all loci is used.}
 
 \item{ignore_strand}{Whether to use strand information in BED file.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 }
 \description{
 Calculate heatmap matrix of a bigWig file over a BED file

--- a/man/bw_profile.Rd
+++ b/man/bw_profile.Rd
@@ -15,7 +15,7 @@ bw_profile(
   downstream = 2500,
   middle = NULL,
   ignore_strand = FALSE,
-  norm_func = identity,
+  norm_mode = "fc",
   remove_top = 0
 )
 }
@@ -52,7 +52,8 @@ mode). If not provided, median length of all loci is used.}
 
 \item{ignore_strand}{Whether to use strand information in BED file.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/man/calculate_bw_profile.Rd
+++ b/man/calculate_bw_profile.Rd
@@ -50,7 +50,7 @@ mode). If not provided, median length of all loci is used.}
 
 \item{ignore_strand}{Whether to use strand information in BED file.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_func}{Normalization function}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/man/calculate_matrix_norm.Rd
+++ b/man/calculate_matrix_norm.Rd
@@ -47,7 +47,7 @@ mode). If not provided, median length of all loci is used.}
 
 \item{ignore_strand}{Whether to use strand information in BED file.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_func}{Normalization function}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/man/plot_bw_bins_scatter.Rd
+++ b/man/plot_bw_bins_scatter.Rd
@@ -9,8 +9,8 @@ plot_bw_bins_scatter(
   y,
   bg_x = NULL,
   bg_y = NULL,
-  norm_func_x = identity,
-  norm_func_y = identity,
+  norm_mode_x = "fc",
+  norm_mode_y = "fc",
   bin_size = 10000,
   genome = "mm9",
   highlight = NULL,
@@ -30,9 +30,9 @@ plot_bw_bins_scatter(
 
 \item{bg_y}{BigWig file to be used as y axis background (us. input).}
 
-\item{norm_func_x}{Function to use after x / x_bg.}
+\item{norm_mode_x}{Normalization mode for x axis.}
 
-\item{norm_func_y}{Function to use after y / y_bg.}
+\item{norm_mode_y}{Normalization mode for y axis.}
 
 \item{bin_size}{Bin size.}
 

--- a/man/plot_bw_bins_violin.Rd
+++ b/man/plot_bw_bins_violin.Rd
@@ -13,7 +13,7 @@ plot_bw_bins_violin(
   genome = "mm9",
   highlight = NULL,
   minoverlap = 0L,
-  norm_func = identity,
+  norm_mode = "fc",
   highlight_label = NULL,
   highlight_colors = NULL,
   remove_top = 0,
@@ -40,7 +40,8 @@ Choices: min, max, sd, mean.}
 
 \item{minoverlap}{Minimum overlap required for a bin to be highlighted.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{highlight_label}{Label for the highlighted loci set}
 

--- a/man/plot_bw_loci_scatter.Rd
+++ b/man/plot_bw_loci_scatter.Rd
@@ -10,8 +10,8 @@ plot_bw_loci_scatter(
   loci,
   bg_x = NULL,
   bg_y = NULL,
-  norm_func_x = identity,
-  norm_func_y = identity,
+  norm_mode_x = "fc",
+  norm_mode_y = "fc",
   highlight = NULL,
   minoverlap = 0L,
   highlight_label = NULL,
@@ -31,9 +31,9 @@ plot_bw_loci_scatter(
 
 \item{bg_y}{BigWig file to be used as y axis background (us. input).}
 
-\item{norm_func_x}{Function to use after x / x_bg.}
+\item{norm_mode_x}{Normalization mode for x axis.}
 
-\item{norm_func_y}{Function to use after y / y_bg.}
+\item{norm_mode_y}{Normalization mode for y axis.}
 
 \item{highlight}{List of bed files to use as highlight for subgroups.}
 

--- a/man/plot_bw_loci_summary_heatmap.Rd
+++ b/man/plot_bw_loci_summary_heatmap.Rd
@@ -10,7 +10,7 @@ plot_bw_loci_summary_heatmap(
   bg_bwfiles = NULL,
   labels = NULL,
   aggregate_by = "true_mean",
-  norm_func = identity,
+  norm_mode = "fc",
   remove_top = 0,
   verbose = TRUE
 )
@@ -28,7 +28,8 @@ background.}
 \item{aggregate_by}{Statistic to aggregate per group. If NULL, values are
 not aggregated. This is the behavior by default.}
 
-\item{norm_func}{Function to apply to normalize bin values f(bw / bw_bg).}
+\item{norm_mode}{Function to apply to normalize bin values. Default fc:
+divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -179,7 +179,7 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
                 bg_bwfiles = bg_x,
                 bin_size = bin_size,
                 genome = genome,
-                norm_func = norm_func_x,
+                norm_mode = norm_mode_x,
                 labels = "x"
               )
   )
@@ -189,7 +189,7 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
               bg_bwfiles = bg_bw,
               bin_size = 10000,
               genome = "mm9",
-              norm_func = identity,
+              norm_mode = "fc",
               labels = "x"
   )
 
@@ -198,7 +198,7 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
               bg_bwfiles = bg_bw,
               bin_size = 10000,
               genome = "mm9",
-              norm_func = identity,
+              norm_mode = "fc",
               labels = "y"
   )
 })
@@ -265,7 +265,7 @@ test_that("plot_bw_bins_violin with highlight and remove top returns a plot", {
                                   labels = c("A", "B"),
                                   highlight = bed,
                                   bin_size = 5000,
-                                  norm_func = log2,
+                                  norm_mode = "log2fc",
                                   genome = "hg38",
                                   remove_top = 0.01,
                                   verbose = FALSE)
@@ -284,7 +284,7 @@ test_that("plot_bw_bins_violin passes on parameters", {
                              labels = c("A", "B"),
                              highlight = bed,
                              bin_size = 5000,
-                             norm_func = log2,
+                             norm_mode = "log2fc",
                              genome = "hg38",
                              remove_top = 0
     )
@@ -297,7 +297,7 @@ test_that("plot_bw_bins_violin passes on parameters", {
                       bin_size = bin_size,
                       genome = genome,
                       per_locus_stat = per_locus_stat,
-                      norm_func = norm_func,
+                      norm_mode = norm_mode,
                       # FIXME: Remove top is done outside this function
                       remove_top = 0
               )
@@ -310,7 +310,7 @@ test_that("plot_bw_bins_violin passes on parameters", {
               bin_size = 5000,
               genome = "hg38",
               per_locus_stat = "mean",
-              norm_func = log2,
+              norm_mode = "log2fc",
               remove_top = 0
   )
 
@@ -355,7 +355,7 @@ test_that(
                                        loci = bed,
                                        bg_bwfiles <- c(bg_bw, bg_bw),
                                        aggregate_by = "median",
-                                       norm_func = log2,
+                                       norm_mode = "log2fc",
                                        labels = c("bw1", "bw2")
       )
     })
@@ -365,7 +365,7 @@ test_that(
                        loci,
                        bg_bwfiles = bg_bwfiles,
                        aggregate_by = aggregate_by,
-                       norm_func = norm_func,
+                       norm_mode = norm_mode,
                        labels = labels,
                        remove_top = remove_top
                 )
@@ -376,7 +376,7 @@ test_that(
                 loci = bed,
                 bg_bwfiles = c(bg_bw, bg_bw),
                 aggregate_by = "median",
-                norm_func = log2,
+                norm_mode = "log2fc",
                 labels = c("bw1", "bw2"),
                 remove_top = 0
     )

--- a/vignettes/bwtools.Rmd
+++ b/vignettes/bwtools.Rmd
@@ -95,15 +95,18 @@ bw_bins(h33_chip, bg_bwfiles = input_chip,
         genome = "mm9",
         selection = locus)
 ```
-If `log2` is passed as `norm_func` parameter, we get the log2 ratio sample / input:
+If you want to get the log2 ratio sample / input, select `norm_mode = "log2fc"`:
 
 ```{r, warning = FALSE, message = FALSE}
 bw_bins(h33_chip, bg_bwfiles = input_chip,
         bin_size = 50000,
         genome = "mm9",
         selection = locus,
-        norm_func = log2) # Note this is not a string, but the actual function
+        norm_mode = "log2fc")
 ```
+
+`norm_mode` is set to `"fc"` by default, which means it shows fold change 
+sample / input, if input (background) is provided.
 
 ## Supported genomes
 
@@ -266,7 +269,7 @@ bw_bins(c(h33_chip, input_chip),
         bin_size = 50000,
         genome = "mm9",
         selection = locus,
-        norm_func = log2) # Note this is not a string, but the actual function
+        norm_mode = "log2fc")
 ```
 
 It is advised against implementing future planning within library function 


### PR DESCRIPTION
I have had a lot of questions about `norm_func` and how does it work. It was a very confusing and error-prone decision. I have switched to `norm_mode` parameter that takes a string. At this point, it only accepts two options `"fc"` and `"log2fc"`. But if is feasible to implement other options, like log2 fold change +1, for example.

Resolves #17 