### PR TITLE
Add order_by heatmap parameter + tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.10.0
+Version: 0.11.0
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -203,6 +203,10 @@ plot_bw_bins_violin <- function(bwfiles,
 #'   on the y axis until it fits max_rows_allowed. This speeds up plotting of
 #'   very large matrices, where higher resolution would not be perceivable by eye.
 #' @param verbose Put a caption with relevant parameters on the plot.
+#' @param order_by Specific order to display rows. By default rows are sorted
+#'   decreasingly by mean. Order should be an array of integers of the same
+#'   length as number of rows. These can be obtained as a result of order()
+#'   function, if one would want to sort one heatmap by values on another one.
 #' @importFrom dplyr group_by summarise
 #' @importFrom RColorBrewer brewer.pal
 #' @importFrom grDevices colorRampPalette
@@ -222,6 +226,7 @@ plot_bw_heatmap <- function(bwfile,
                             zmin = NULL,
                             zmax = NULL,
                             max_rows_allowed = 10000,
+                            order_by = NULL,
                             verbose = TRUE) {
   values <- bw_heatmap(
     bwfile,
@@ -237,7 +242,7 @@ plot_bw_heatmap <- function(bwfile,
   )
 
   main_plot <-
-    .heatmap_body(values[[1]], zmin, zmax, cmap, max_rows_allowed)
+    .heatmap_body(values[[1]], zmin, zmax, cmap, max_rows_allowed, order_by)
 
   verbose_tag <- NULL
   if (verbose) {
@@ -511,9 +516,12 @@ plot_bw_profile <- function(bwfiles,
 #' @inheritParams plot_bw_heatmap
 #'
 #' @return Named list plot and calculated values
-.heatmap_body <- function(values, zmin, zmax, cmap, max_rows_allowed) {
+.heatmap_body <- function(values, zmin, zmax, cmap, max_rows_allowed, order_by) {
   # Order matrix by mean and transpose it (image works flipped)
-  m <- t(values[order(rowMeans(values), decreasing = F), ])
+  if (is.null(order_by)) {
+    order_by <- order(rowMeans(values), decreasing = F)
+  }
+  m <- t(values[order_by, ])
 
   nvalues <- nrow(m) * ncol(m)
 

--- a/man/dot-heatmap_body.Rd
+++ b/man/dot-heatmap_body.Rd
@@ -4,7 +4,7 @@
 \alias{.heatmap_body}
 \title{Helper function for matrix heatmap plot}
 \usage{
-.heatmap_body(values, zmin, zmax, cmap, max_rows_allowed)
+.heatmap_body(values, zmin, zmax, cmap, max_rows_allowed, order_by)
 }
 \arguments{
 \item{values}{Matrix with values}
@@ -21,6 +21,11 @@ this to 0.99.}
 plot. If the amount of loci exceeds this value, the plot will be binned
 on the y axis until it fits max_rows_allowed. This speeds up plotting of
 very large matrices, where higher resolution would not be perceivable by eye.}
+
+\item{order_by}{Specific order to display rows. By default rows are sorted
+decreasingly by mean. Order should be an array of integers of the same
+length as number of rows. These can be obtained as a result of order()
+function, if one would want to sort one heatmap by values on another one.}
 }
 \value{
 Named list plot and calculated values

--- a/man/plot_bw_heatmap.Rd
+++ b/man/plot_bw_heatmap.Rd
@@ -19,6 +19,7 @@ plot_bw_heatmap(
   zmin = NULL,
   zmax = NULL,
   max_rows_allowed = 10000,
+  order_by = NULL,
   verbose = TRUE
 )
 }
@@ -67,6 +68,11 @@ this to 0.99.}
 plot. If the amount of loci exceeds this value, the plot will be binned
 on the y axis until it fits max_rows_allowed. This speeds up plotting of
 very large matrices, where higher resolution would not be perceivable by eye.}
+
+\item{order_by}{Specific order to display rows. By default rows are sorted
+decreasingly by mean. Order should be an array of integers of the same
+length as number of rows. These can be obtained as a result of order()
+function, if one would want to sort one heatmap by values on another one.}
 
 \item{verbose}{Put a caption with relevant parameters on the plot.}
 }

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -4,6 +4,8 @@ library(testthat)
 library(mockery)
 
 
+# Setup -------------------------------------------------------------------
+
 get_file_path <- function(filename) {
   system.file("extdata", filename, package = "wigglescout")
 }
@@ -46,6 +48,8 @@ test_that("Setup files exist", {
 })
 
 
+# Bins scatter tests ----------------------------------------------
+
 test_that("plot_bw_bins_scatter with defaults returns a plot", {
   m <- mock(reduced_bins, reduced_bins_2)
   with_mock(bw_bins = m, {
@@ -53,15 +57,6 @@ test_that("plot_bw_bins_scatter with defaults returns a plot", {
     expect_is(p, "ggplot")
   })
 })
-
-test_that("plot_bw_loci_scatter with defaults returns a plot", {
-  m <- mock(reduced_bins, reduced_bins_2)
-  with_mock(bw_bins = m, {
-    p <- plot_bw_loci_scatter(bw1, bw2, bed)
-    expect_is(p, "ggplot")
-  })
-})
-
 
 test_that("plot_bw_bins_scatter with highlight set returns a plot", {
   m <- mock(reduced_bins, reduced_bins_2)
@@ -71,46 +66,10 @@ test_that("plot_bw_bins_scatter with highlight set returns a plot", {
   })
 })
 
-test_that("plot_bw_loci_scatter with highlight set returns a plot", {
-  m <- mock(reduced_bins, reduced_bins_2)
-  with_mock(bw_bins = m, {
-    p <- plot_bw_loci_scatter(bw1, bw2, bed, highlight = bed)
-    expect_is(p, "ggplot")
-  })
-})
-
-
 test_that("plot_bw_bins_scatter with verbose set returns a plot with a caption", {
   m <- mock(reduced_bins, reduced_bins_2)
   with_mock(bw_bins = m, {
     p <- plot_bw_bins_scatter(bw1, bw2, highlight = bed, verbose = TRUE)
-    expect_is(p, "ggplot")
-    expect_false(is.null(p$labels$caption))
-  })
-})
-
-test_that("plot_bw_loci_scatter with verbose set returns a plot with a caption", {
-  m <- mock(reduced_bins, reduced_bins_2)
-  with_mock(bw_bins = m, {
-    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = TRUE)
-    expect_is(p, "ggplot")
-    expect_false(is.null(p$labels$caption))
-  })
-})
-
-test_that("plot_bw_loci_scatter no verbose returns a plot with no caption", {
-  m <- mock(reduced_bins, reduced_bins_2)
-  with_mock(bw_bins = m, {
-    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = FALSE)
-    expect_is(p, "ggplot")
-    expect_true(is.null(p$labels$caption))
-  })
-})
-
-test_that("plot_bw_loci_scatter with remove_top returns a plot", {
-  m <- mock(reduced_bins, reduced_bins_2)
-  with_mock(bw_bins = m, {
-    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = TRUE, remove_top=0.01)
     expect_is(p, "ggplot")
     expect_false(is.null(p$labels$caption))
   })
@@ -155,7 +114,6 @@ test_that("plot_bw_bins_scatter crashes with unmatched labels/highlight", {
     )
   })
 })
-
 
 test_that("plot_bw_bins_scatter with GRanges and no label crashes", {
   m <- mock(reduced_bins, reduced_bins_2)
@@ -222,6 +180,52 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
 })
 
 
+# Loci scatter tests ----------------------------------------------
+
+test_that("plot_bw_loci_scatter with defaults returns a plot", {
+  m <- mock(reduced_bins, reduced_bins_2)
+  with_mock(bw_bins = m, {
+    p <- plot_bw_loci_scatter(bw1, bw2, bed)
+    expect_is(p, "ggplot")
+  })
+})
+
+test_that("plot_bw_loci_scatter with highlight set returns a plot", {
+  m <- mock(reduced_bins, reduced_bins_2)
+  with_mock(bw_bins = m, {
+    p <- plot_bw_loci_scatter(bw1, bw2, bed, highlight = bed)
+    expect_is(p, "ggplot")
+  })
+})
+
+test_that("plot_bw_loci_scatter with verbose set returns a plot with a caption", {
+  m <- mock(reduced_bins, reduced_bins_2)
+  with_mock(bw_bins = m, {
+    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = TRUE)
+    expect_is(p, "ggplot")
+    expect_false(is.null(p$labels$caption))
+  })
+})
+
+test_that("plot_bw_loci_scatter no verbose returns a plot with no caption", {
+  m <- mock(reduced_bins, reduced_bins_2)
+  with_mock(bw_bins = m, {
+    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = FALSE)
+    expect_is(p, "ggplot")
+    expect_true(is.null(p$labels$caption))
+  })
+})
+
+test_that("plot_bw_loci_scatter with remove_top returns a plot", {
+  m <- mock(reduced_bins, reduced_bins_2)
+  with_mock(bw_bins = m, {
+    p <- plot_bw_loci_scatter(bw1, bw2, loci = bed, verbose = TRUE, remove_top=0.01)
+    expect_is(p, "ggplot")
+    expect_false(is.null(p$labels$caption))
+  })
+})
+
+# Bins violin tests ----------------------------------------------
 
 test_that("plot_bw_bins_violin with defaults returns a plot", {
   m <- mock(reduced_bins_all)
@@ -300,7 +304,6 @@ test_that("plot_bw_bins_violin with highlight and remove top returns a plot", {
   })
 })
 
-
 test_that("plot_bw_bins_violin passes on parameters", {
   m <- mock(reduced_bins_all)
   with_mock(bw_bins = m, {
@@ -341,7 +344,7 @@ test_that("plot_bw_bins_violin passes on parameters", {
 
 })
 
-
+# Summary heatmap tests -------------------------------------------
 
 test_that(
   "plot_bw_loci_summary_heatmap with defaults returns a ggplot object", {
@@ -369,7 +372,6 @@ test_that("plot_bw_loci_summary_heatmap with verbose unset returns a plot withou
     expect_true(is.null(p$labels$caption))
   })
 })
-
 
 test_that(
   "plot_bw_loci_summary_heatmap passes parameters on", {
@@ -406,6 +408,7 @@ test_that(
     )
   })
 
+# Profile tests ----------------------------------------------
 
 test_that(
   "plot_bw_profile with defaults returns a ggplot object", {
@@ -425,7 +428,6 @@ test_that(
       expect_true("GeomRibbon" %in% sapply(p$layers, function(x) class(x$geom)[1]))
     })
   })
-
 
 test_that(
   "plot_bw_profile verbose returns a plot with a caption", {
@@ -473,7 +475,6 @@ test_that(
       expect_true(is.null(p$labels$caption))
     })
   })
-
 
 test_that(
   "plot_bw_profile passes on parameters to bw_profile call", {
@@ -526,25 +527,62 @@ test_that(
     )
   })
 
+# Heatmap tests ----------------------------------------------
+
 test_that(
   "plot_bw_heatmap with defaults returns a ggplot object", {
-    m <- mock(profile_values)
-    with_mock(bw_profile = m, {
+    m <- mock(heatmap_values)
+    with_mock(bw_heatmap = m, {
       p <- plot_bw_heatmap(bw1, bedfile = bed)
       expect_is(p, "ggplot")
     })
   })
 
 test_that(
-  "plot_bw_heatmap with verbose returns a ggplot object wit ha caption", {
-    m <- mock(profile_values)
-    with_mock(bw_profile = m, {
+  "plot_bw_heatmap sorts decreasingly by mean", {
+    m <- mock(heatmap_values, heatmap_values)
+    # y axis works reversed here
+    other_order <- order(rowMeans(heatmap_values[[1]]), decreasing = F)
+    with_mock(bw_heatmap = m, {
+      p <- plot_bw_heatmap(bw1, bedfile = bed)
+      p2 <- plot_bw_heatmap(bw1, bedfile = bed, order_by = other_order)
+      expect_is(p, "ggplot")
+      expect_identical(p$data, p2$data)
+    })
+  })
+
+test_that(
+  "plot_bw_heatmap with order returns a ggplot object", {
+    m <- mock(heatmap_values)
+    other_order <- order(rowMeans(heatmap_values[[1]]), decreasing = T)
+    with_mock(bw_heatmap = m, {
+      p <- plot_bw_heatmap(bw1, bedfile = bed, order_by = other_order)
+      expect_is(p, "ggplot")
+    })
+  })
+
+test_that(
+  "plot_bw_heatmap with different order returns a different ggplot", {
+    m <- mock(heatmap_values, heatmap_values)
+    other_order <- order(rowMeans(heatmap_values[[1]]), decreasing = T)
+    with_mock(bw_heatmap = m, {
+      p <- plot_bw_heatmap(bw1, bedfile = bed, order_by = other_order)
+      p2 <- plot_bw_heatmap(bw1, bedfile = bed)
+
+      expect_is(p, "ggplot")
+      expect_false(p$data[1, "value"] == p2$data[1, "value"])
+    })
+  })
+
+test_that(
+  "plot_bw_heatmap with verbose returns a ggplot object with a caption", {
+    m <- mock(heatmap_values)
+    with_mock(bw_heatmap = m, {
       p <- plot_bw_heatmap(bw1, bedfile = bed)
       expect_is(p, "ggplot")
       expect_true("caption" %in% names(p$labels))
     })
   })
-
 
 test_that(
   "plot_bw_heatmap passes on parameters to bw_heatmap call", {


### PR DESCRIPTION
Now `plot_bw_heatmap` function has another `order_by` parameter to sort rows in a different way if necessary.

Tests have been added and also the default by mean function is tested.