### PR TITLE
Add selection parameter for speed up examples

### DIFF
--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -49,14 +49,16 @@ plot_bw_bins_scatter <- function(x,
                                  highlight_colors = NULL,
                                  remove_top = 0,
                                  verbose = TRUE,
-                                 density = FALSE) {
+                                 density = FALSE,
+                                 selection = NULL) {
   bins_x <- bw_bins(
     x,
     bg_bwfiles = bg_x,
     bin_size = bin_size,
     genome = genome,
     norm_mode = norm_mode_x,
-    labels = "score"
+    labels = "score",
+    selection = selection
   )
 
   bins_y <- bw_bins(
@@ -65,7 +67,8 @@ plot_bw_bins_scatter <- function(x,
     bin_size = bin_size,
     genome = genome,
     norm_mode = norm_mode_y,
-    labels = "score"
+    labels = "score",
+    selection = selection
   )
 
   highlight_data <- .convert_and_label_loci(highlight, highlight_label)
@@ -134,7 +137,8 @@ plot_bw_bins_violin <- function(bwfiles,
                                 highlight_label = NULL,
                                 highlight_colors = NULL,
                                 remove_top = 0,
-                                verbose = TRUE) {
+                                verbose = TRUE,
+                                selection = NULL) {
   bins_values <- bw_bins(
     bwfiles,
     bg_bwfiles = bg_bwfiles,
@@ -143,7 +147,8 @@ plot_bw_bins_violin <- function(bwfiles,
     genome = genome,
     per_locus_stat = per_locus_stat,
     norm_mode = norm_mode,
-    remove_top = 0
+    remove_top = 0,
+    selection = selection
   )
 
   columns <- labels

--- a/man/plot_bw_bins_scatter.Rd
+++ b/man/plot_bw_bins_scatter.Rd
@@ -19,7 +19,8 @@ plot_bw_bins_scatter(
   highlight_colors = NULL,
   remove_top = 0,
   verbose = TRUE,
-  density = FALSE
+  density = FALSE,
+  selection = NULL
 )
 }
 \arguments{
@@ -54,6 +55,10 @@ whole distribution (remove_top == 0).}
 \item{verbose}{Put a caption with relevant parameters on the plot.}
 
 \item{density}{Plot density tiles for global distribution instead of points.}
+
+\item{selection}{A GRanges object to restrict binning to a certain set of
+intervals. This is useful for debugging and improving performance of
+locus specific analyses.}
 }
 \value{
 A ggplot object.

--- a/man/plot_bw_bins_violin.Rd
+++ b/man/plot_bw_bins_violin.Rd
@@ -17,7 +17,8 @@ plot_bw_bins_violin(
   highlight_label = NULL,
   highlight_colors = NULL,
   remove_top = 0,
-  verbose = TRUE
+  verbose = TRUE,
+  selection = NULL
 )
 }
 \arguments{
@@ -51,6 +52,10 @@ divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 whole distribution (remove_top == 0).}
 
 \item{verbose}{Put a caption with relevant parameters on the plot.}
+
+\item{selection}{A GRanges object to restrict binning to a certain set of
+intervals. This is useful for debugging and improving performance of
+locus specific analyses.}
 }
 \value{
 A ggplot object.

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -58,6 +58,11 @@ test_that("plot_bw_bins_scatter with defaults returns a plot", {
   })
 })
 
+test_that("plot_bw_bins_scatter with selection returns a plot", {
+  p <- plot_bw_bins_scatter(bw1, bw2, selection = bw_limits)
+  expect_is(p, "ggplot")
+})
+
 test_that("plot_bw_bins_scatter with highlight set returns a plot", {
   m <- mock(reduced_bins, reduced_bins_2)
   with_mock(bw_bins = m, {
@@ -156,7 +161,8 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
                 bin_size = bin_size,
                 genome = genome,
                 norm_mode = norm_mode_x,
-                labels = "score"
+                labels = "score",
+                selection = selection
               )
   )
 
@@ -166,7 +172,8 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
               bin_size = 10000,
               genome = "mm9",
               norm_mode = "fc",
-              labels = "score"
+              labels = "score",
+              selection = NULL
   )
 
   expect_args(m, 2,
@@ -175,7 +182,8 @@ test_that("plot_bw_bins_scatter with bg files passes on parameters", {
               bin_size = 10000,
               genome = "mm9",
               norm_mode = "fc",
-              labels = "score"
+              labels = "score",
+              selection = NULL
   )
 })
 
@@ -314,7 +322,7 @@ test_that("plot_bw_bins_violin passes on parameters", {
                              bin_size = 5000,
                              norm_mode = "log2fc",
                              genome = "hg38",
-                             remove_top = 0
+                             remove_top = 0,
     )
   })
 
@@ -327,7 +335,8 @@ test_that("plot_bw_bins_violin passes on parameters", {
                       per_locus_stat = per_locus_stat,
                       norm_mode = norm_mode,
                       # FIXME: Remove top is done outside this function
-                      remove_top = 0
+                      remove_top = 0,
+                      selection = selection
               )
   )
 
@@ -339,7 +348,8 @@ test_that("plot_bw_bins_violin passes on parameters", {
               genome = "hg38",
               per_locus_stat = "mean",
               norm_mode = "log2fc",
-              remove_top = 0
+              remove_top = 0,
+              selection = NULL
   )
 
 })


### PR DESCRIPTION
Vignettes building was becoming very lengthy because of plotting bin-based examples do not care that there is only signal in a small part of the genome. 

Resolves #37