### PR TITLE
Maintain row order from top to bottom in summary heatmaps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.12.0
+Version: 0.12.1
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -673,13 +673,19 @@ plot_bw_profile <- function(bwfiles,
     warning("All zero-values matrix. Using same background as bw input?")
   }
   values <- round(values, 2)
+
+  # y axis goes from bottom to top!
+  sample_names <- rev(colnames(values))
   values$type <- rownames(values)
 
   # Natural sort
   ordered_levels <- stringr::str_sort(values$type, numeric = TRUE)
   values$type <- factor(values$type, levels=ordered_levels)
 
+
   vals_long <- melt(values, id.vars = "type")
+  vals_long$variable <- factor(vals_long$variable, levels=sample_names)
+
 
   plot <-
     ggplot(vals_long, aes_string("type", "variable", fill = "value")) +


### PR DESCRIPTION
Additionally realised that rows were ordered from bottom to top, as that's how the y axis goes, which is non-intuitive in this case. Now rows are ordered from top to bottom and match either the order of the `labels` parameter or the files given.

Fixes #50