### PR TITLE
Plot profile normalizes post aggregation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.12.3
+Version: 0.12.4
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -528,6 +528,11 @@ plot_bw_profile <- function(bwfiles,
     verbose_tag <- make_caption(relevant_params, list())
   }
 
+  if (!is.null(bg_bwfiles) && show_error == TRUE) {
+    warning("Error estimate not available when normalizing by input")
+    show_error <- FALSE
+  }
+
   .profile_body(values, show_error, colors) +
     .heatmap_lines(nloci, max(values$index), bin_size,
                          upstream, downstream, mode) +

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -460,6 +460,18 @@ test_that(
   })
 
 test_that(
+  "plot_bw_profile with show_error and background does not have ribbon layer", {
+    m <- mock(profile_values)
+    with_mock(bw_profile = m, {
+      expect_warning({p <- plot_bw_profile(bw1, bg_bwfiles = bw2, loci = bed, show_error=TRUE)},
+                     "Error estimate not available when normalizing by input")
+
+      expect_is(p, "ggplot")
+      expect_false("GeomRibbon" %in% sapply(p$layers, function(x) class(x$geom)[1]))
+    })
+  })
+
+test_that(
   "plot_bw_profile verbose returns a plot with a caption", {
     m <- mock(profile_values)
     with_mock(bw_profile = m, {
@@ -519,7 +531,7 @@ test_that(
                            downstream = 1500,
                            middle = 1000,
                            ignore_strand = TRUE,
-                           show_error = TRUE,
+                           show_error = FALSE,
                            norm_mode = "log2fc",
                            remove_top = 0,
                            labels = c("bw1", "bw2"),


### PR DESCRIPTION
Fixes #57

Note that error estimates in the case of norm mode in profile now do not make too much sense, as the final value is a transformation of aggregated values.

To make this clear, `plot_bw_profile` now shows a warning if background is provided and `show_error == TRUE`.