### PR TITLE
Fix for labels in bw_loci

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.12.4
+Version: 0.12.5
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwtools.R
+++ b/R/bwtools.R
@@ -53,6 +53,9 @@ bw_loci <- function(bwfiles,
 
   if (is.null(labels)) {
     labels <- make_label_from_object(bwfiles)
+  } else {
+    # Ensures later on we only try to access valid labels
+    labels <- make.names(labels)
   }
 
   bed <- loci_to_granges(loci)

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -365,6 +365,24 @@ test_that(
     })
   })
 
+test_that(
+  "plot_bw_loci_summary_heatmap with labels returns a ggplot object", {
+    m <- mock(summary_values)
+    with_mock(bw_loci = m, {
+      p <- plot_bw_loci_summary_heatmap(c(bw1, bw2), loci = bed, labels = c("A", "B"))
+      expect_is(p, "ggplot")
+    })
+  })
+
+test_that(
+  "plot_bw_loci_summary_heatmap with labels including invalid chars returns a ggplot object", {
+    m <- mock(summary_values)
+    with_mock(bw_loci = m, {
+      p <- plot_bw_loci_summary_heatmap(c(bw1, bw2), loci = bed, labels = c("A-1", "B-2"))
+      expect_is(p, "ggplot")
+    })
+  })
+
 test_that("plot_bw_loci_summary_heatmap with verbose set returns a plot with a caption", {
   m <- mock(reduced_bins, reduced_bins_2)
   with_mock(bw_bins = m, {


### PR DESCRIPTION
If running `plot_bw_summary_heatmap` with `labels` that contain invalid characters in R, the function crashed due to the default adaptation R does calling `make.names`. Fixed it replacing `labels` in `bw_loci` with `make.names(labels)` to ensure the same labels are used throughout.