### PR TITLE
Make profile plots legends transparent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.12.5
+Version: 0.12.6
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -646,7 +646,8 @@ plot_bw_profile <- function(bwfiles,
     theme(
       legend.position = c(0.80, 0.90),
       legend.direction = "vertical",
-      legend.title = element_blank()
+      legend.title = element_blank(),
+      legend.background = element_rect(fill = alpha("white", 0.3))
     )
 
   if (!is.null(colors)) {


### PR DESCRIPTION
To avoid problems when lines fall under the legend. Fixes #62 