### PR TITLE
plot_bw_profile accepts now multiple loci for a single bwfile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.12.8
+Version: 0.13.0
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -497,22 +497,51 @@ plot_bw_profile <- function(bwfiles,
                             remove_top = 0,
                             verbose = TRUE) {
 
-  values <- bw_profile(bwfiles, loci,
-    bg_bwfiles = bg_bwfiles,
-    mode = mode,
-    bin_size = bin_size,
-    upstream = upstream,
-    downstream = downstream,
-    middle = middle,
-    ignore_strand = ignore_strand,
-    norm_mode = norm_mode,
-    labels = labels,
-    remove_top = remove_top
-  )
+  values <- NULL
+  nloci <- NULL
+  x_label <- ""
 
-  nloci <- loci_length(loci)
+  if ((class(loci) == "list" && length(loci) > 1) || (class(loci) == "character" && length(loci) > 1)) {
+    if (length(bwfiles) > 1) {
+      stop("If multiple loci provided only a single bwfile is allowed")
+    }
+    if (is.null(labels)) {
+      labels <- make_label_from_object(loci)
+    }
+    profile_function <- purrr::partial(bw_profile, bwfile = bwfiles,
+                                       bg_bwfiles = bg_bwfiles,
+                                       mode = mode,
+                                       bin_size = bin_size,
+                                       upstream = upstream,
+                                       downstream = downstream,
+                                       middle = middle,
+                                       ignore_strand = ignore_strand,
+                                       norm_mode = norm_mode,
+                                       remove_top = remove_top)
+
+    value_list <- purrr::map2(loci, labels, profile_function)
+    values <- do.call(rbind, value_list)
+    x_title <- "Multiple loci groups"
+  }
+  else {
+    values <- bw_profile(bwfiles, loci, bg_bwfiles = bg_bwfiles,
+                         mode = mode,
+                         bin_size = bin_size,
+                         upstream = upstream,
+                         downstream = downstream,
+                         middle = middle,
+                         ignore_strand = ignore_strand,
+                         norm_mode = norm_mode,
+                         labels = labels,
+                         remove_top = remove_top)
+
+
+    nloci <- loci_length(loci)
+    x_title <- paste(make_label_from_object(loci), "-", nloci, "loci", sep = " ")
+  }
+
   y_label <- make_norm_label(norm_mode, bg_bwfiles)
-  x_title <- paste(make_label_from_object(loci), "-", nloci, "loci", sep = " ")
+
 
   verbose_tag <- NULL
   if (verbose) {

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -456,6 +456,33 @@ test_that(
     })
   })
 
+test_that(
+  "plot_bw_profile with GRanges list returns a ggplot object", {
+    m <- mock(profile_values, cycle = TRUE)
+    with_mock(bw_profile = m, {
+      p <- plot_bw_profile(bw1, loci = list(import(bed), import(bed)))
+      expect_is(p, "ggplot")
+    })
+  })
+
+test_that(
+  "plot_bw_profile with loci file list returns a ggplot object", {
+    m <- mock(profile_values, cycle = TRUE)
+    with_mock(bw_profile = m, {
+      p <- plot_bw_profile(bw1, loci = c(bed, bed))
+      expect_is(p, "ggplot")
+    })
+  })
+
+test_that(
+  "plot_bw_profile with loci file list and bwlist fails", {
+    m <- mock(profile_values, cycle = TRUE)
+    with_mock(bw_profile = m, {
+      expect_error(p <- plot_bw_profile(c(bw1, bw2), loci = c(bed, bed)),
+                   "If multiple loci provided only a single bwfile is allowed")
+
+    })
+  })
 
 test_that(
   "plot_bw_profile with defaults has a line layer", {


### PR DESCRIPTION
The idea is that now the same profile can plot different loci groups. This is useful for pile ups and heatmap panels. At this moment, only 1:n relationships are allowed, so it's either single bigWig, multiple loci, or single loci, multiple bigWig.

This functionality only exists in the `plot_bw_profile` function, and not in the `bw_profile` function.
