### PR TITLE
Fix loci label issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore And Visualize Genomics BigWig Data
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -506,7 +506,11 @@ plot_bw_profile <- function(bwfiles,
       stop("If multiple loci provided only a single bwfile is allowed")
     }
     if (is.null(labels)) {
-      labels <- make_label_from_object(loci)
+      labels <- lapply(loci, make_label_from_object)
+      if (length(unique(labels)) < length(loci)) {
+        warning("Unlabeled objects or repeated labels. Adding numeric indices.")
+        labels <- paste(labels, 1:length(labels), sep = "_")
+      }
     }
     profile_function <- purrr::partial(bw_profile, bwfile = bwfiles,
                                        bg_bwfiles = bg_bwfiles,

--- a/tests/testthat/test-bwplot.R
+++ b/tests/testthat/test-bwplot.R
@@ -460,8 +460,18 @@ test_that(
   "plot_bw_profile with GRanges list returns a ggplot object", {
     m <- mock(profile_values, cycle = TRUE)
     with_mock(bw_profile = m, {
-      p <- plot_bw_profile(bw1, loci = list(import(bed), import(bed)))
+      p <- plot_bw_profile(bw1, loci = list(import(bed), import(bed)), labels = c("A", "B"))
       expect_is(p, "ggplot")
+    })
+  })
+
+test_that(
+  "plot_bw_profile with GRanges list and no labels throws warning", {
+    m <- mock(profile_values, cycle = TRUE)
+    with_mock(bw_profile = m, {
+      expect_warning(p <- plot_bw_profile(bw1, loci = list(import(bed), import(bed))),
+                     "Unlabeled objects or repeated labels. Adding numeric indices.")
+
     })
   })
 
@@ -469,7 +479,7 @@ test_that(
   "plot_bw_profile with loci file list returns a ggplot object", {
     m <- mock(profile_values, cycle = TRUE)
     with_mock(bw_profile = m, {
-      p <- plot_bw_profile(bw1, loci = c(bed, bed))
+      p <- plot_bw_profile(bw1, loci = c(bed, bed), labels = c("A", "B"))
       expect_is(p, "ggplot")
     })
   })


### PR DESCRIPTION
If multiple GRanges objects are provided to `plot_bw_profile` and no `labels` parameter is provided, a numbered label is assigned and a warning thrown. Previous version of this collapsed all the datapoints due to colliding labels.