### PR TITLE
Loci NA explicit test

### DIFF
--- a/inst/testdata/labeled_na.bed
+++ b/inst/testdata/labeled_na.bed
@@ -1,0 +1,5 @@
+chr1	20	50	typeA	.	.
+chr1	60	100	typeB	.	.
+chr2	20	40	typeA	.	.
+chr2	110	130	typeB	.	.
+chr2	160	180	typeB	.	.

--- a/tests/testthat/test-bwtools.R
+++ b/tests/testthat/test-bwtools.R
@@ -21,6 +21,7 @@ bg3_zeros <- tempfile("bigwig_bg3", fileext = ".bw")
 bw_special <- tempfile("bigwig-2ñ", fileext = ".bw")
 
 bed_with_names <- system.file("testdata", "labeled.bed", package = "wigglescout")
+bed_with_names_na <- system.file("testdata", "labeled_na.bed", package = "wigglescout")
 unnamed_bed <- system.file("testdata", "not_labeled.bed", package = "wigglescout")
 
 tiles <- tileGenome(c(chr1 = 200, chr2 = 200),
@@ -490,6 +491,19 @@ test_that("bw_loci excludes NA values from mean aggregation", {
 
   expect_equal(values["typeA", "bw4_nas"], 12)
 })
+
+test_that("bw_loci excludes NA values from single locus", {
+    # Here, exclude means that NAs are not counted as zeros, but overlapping
+    # length that has NA value is not counted as valid length.
+    # In this test, a locus 21-50 that has NA on 21-40 and 3 on 41-50 yields
+    # a mean of 3.
+    values <- suppressWarnings(bw_loci(bw4_nas, bed_with_names_na,
+                                       labels = "bw4_nas",
+                                       per_locus_stat = "mean")
+    )
+    expect_equal(values[1]$bw4_nas, 3)
+})
+
 
 test_that("bw_loci fails if aggregate_by in an unnamed bed file", {
   expect_error({


### PR DESCRIPTION
Small PR to add an explicit test to the case where NA values overlap a locus. In this case, a BED file with an empty region is added and used in a single test.

The expected behavior is that if a region includes NA values, these regions are excluded from the average instead of counted as zeros. This is the default behavior of `rtracklayer`. 

If one wants a different behavior, a possible workaround is to explicitly fill the bigWig files used with zeros. `rtracklayer` has an option for this, but right now it is not possible to set this up via `wigglescout` API. In any case, I think this is the right default behavior, since a NA value is semantically closer to "exclude from analysis", and our ChIP data always has explicit zeros.

Since this can be ambiguous, it was relevant to add an explicit test for the expected behavior.

Previous PRs have included ignoring NAs that overlap with full regions, but not partial overlaps. See #88 