### PR TITLE
Add of default_na parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore and Visualize Genomics BigWig Data
-Version: 0.13.9
+Version: 0.14.0
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",
@@ -15,7 +15,7 @@ Description: A set of tools to easily extract, summarize and visualize coverage
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Depends: R (>= 4.1)
 biocViews: Software, Visualization, Sequencing, Coverage, ChIPSeq, ATACSeq
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# wigglescout 0.14.0
+
+* Added a default_na parameter to all the functions. This makes use of 
+ rtracklayer summary function defaultValue parameter. Bins or loci that have
+ no values are replaced by the given value instead. This is particularly useful
+ with very sparse bigWig files, where .aggregate_scores might kill majority
+ of rows due to NA values.
+
 # wigglescout 0.13.9
 
 * .aggregate_scores is robust to presence of NAs. Only rows with no NA

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -165,7 +165,8 @@ plot_bw_bins_violin <- function(bwfiles,
                                 highlight_colors = NULL,
                                 remove_top = 0,
                                 verbose = TRUE,
-                                selection = NULL) {
+                                selection = NULL,
+                                default_na = NA_real_) {
 
     # Get parameter values that are relevant to the underlying function
     par <- .get_wrapper_parameter_values(bw_bins, mget(names(formals())))
@@ -249,9 +250,11 @@ plot_bw_heatmap <- function(bwfiles, loci,
                             zmax = NULL,
                             max_rows_allowed = 10000,
                             order_by = NULL,
-                            verbose = TRUE) {
+                            verbose = TRUE,
+                            default_na = NA_real_) {
     # Get parameter values that are relevant to the underlying function
     par <- .get_wrapper_parameter_values(bw_heatmap, mget(names(formals())))
+
     values <- do.call(bw_heatmap, mget(par))
     df <- .preprocess_heatmap_matrix(values[[1]],
         zmin, zmax,
@@ -318,6 +321,7 @@ plot_bw_heatmap <- function(bwfiles, loci,
 #' @param highlight_colors Array of color values for the highlighting groups
 #' @param remove_top Return range 0-(1-remove_top). By default returns the
 #'     whole distribution (remove_top == 0).
+#' @param default_na Default value for missing values
 #' @param verbose Verbose plot. Returns a plot with all relevant parameters in
 #'   a caption.
 #' @import ggplot2
@@ -348,18 +352,21 @@ plot_bw_loci_scatter <- function(x,
                                 highlight_label = NULL,
                                 highlight_colors = NULL,
                                 remove_top = 0,
-                                verbose = TRUE) {
+                                verbose = TRUE,
+                                default_na = NA_real_) {
 
     values_x <- bw_loci(x, bg_bwfiles = bg_x,
         loci = loci,
         norm_mode = norm_mode_x,
-        labels = "score"
+        labels = "score",
+        default_na = default_na
     )
 
     values_y <- bw_loci(y, bg_bwfiles = bg_y,
         loci = loci,
         norm_mode = norm_mode_y,
-        labels = "score"
+        labels = "score",
+        default_na = default_na
     )
 
     highlight_data <- .convert_and_label_loci(highlight, highlight_label)
@@ -415,7 +422,8 @@ plot_bw_loci_summary_heatmap <- function(bwfiles, loci,
                                         aggregate_by = "true_mean",
                                         norm_mode = "fc",
                                         remove_top = 0,
-                                        verbose = TRUE) {
+                                        verbose = TRUE,
+                                        default_na = NA_real_) {
 
     # Get parameter values that are relevant to the underlying function
     par <- .get_wrapper_parameter_values(bw_loci, mget(names(formals())))
@@ -469,7 +477,8 @@ plot_bw_profile <- function(bwfiles, loci,
                             labels = NULL,
                             colors = NULL,
                             remove_top = 0,
-                            verbose = TRUE) {
+                            verbose = TRUE,
+                            default_na = NA_real_) {
     .validate_input_numbers(bwfiles, loci)
     values <- NULL
     nloci <- NULL
@@ -490,7 +499,8 @@ plot_bw_profile <- function(bwfiles, loci,
             middle = middle,
             ignore_strand = ignore_strand,
             norm_mode = norm_mode,
-            remove_top = remove_top
+            remove_top = remove_top,
+            default_na = default_na
         )
         value_list <- map2(loci, labels, profile_function)
         values <- do.call(rbind, value_list)

--- a/R/bwtools.R
+++ b/R/bwtools.R
@@ -69,7 +69,8 @@ bw_loci <- function(bwfiles,
                     per_locus_stat = "mean",
                     aggregate_by = NULL,
                     norm_mode = "fc",
-                    remove_top = 0) {
+                    remove_top = 0,
+                    default_na = NA_real_) {
 
     .validate_filelist(bwfiles)
     .validate_locus_parameter(loci)
@@ -91,7 +92,8 @@ bw_loci <- function(bwfiles,
                 bwfiles, labels,
                 granges = bed,
                 per_locus_stat = per_locus_stat,
-                remove_top = remove_top
+                remove_top = remove_top,
+                default_na = default_na
             )
         }
         else {
@@ -104,6 +106,7 @@ bw_loci <- function(bwfiles,
                 per_locus_stat = per_locus_stat,
                 norm_func = norm_func,
                 remove_top = remove_top,
+                default_na = default_na
             )
         }
     } else {
@@ -113,7 +116,8 @@ bw_loci <- function(bwfiles,
             granges = bed,
             per_locus_stat = per_locus_stat,
             aggregate_by = aggregate_by,
-            remove_top = remove_top
+            remove_top = remove_top,
+            default_na = default_na
         )
 
         if (!is.null(bg_bwfiles)) {
@@ -123,7 +127,8 @@ bw_loci <- function(bwfiles,
                 granges = bed,
                 per_locus_stat = per_locus_stat,
                 aggregate_by = aggregate_by,
-                remove_top = remove_top
+                remove_top = remove_top,
+                default_na = default_na
             )
 
             rows <- rownames(result)
@@ -166,6 +171,7 @@ bw_loci <- function(bwfiles,
 #'     divides bw / bg. Alternative: log2fc: returns log2(bw/bg).
 #' @param remove_top Return range 0-(1-remove_top). By default returns the
 #'     whole distribution (remove_top == 0).
+#' @param default_na Default value for missing values
 #' @return A GRanges object with each bwfile as a metadata column named
 #'     after labels, if provided, or after filenames otherwise.
 #' @export
@@ -203,7 +209,8 @@ bw_bins <- function(bwfiles,
                     genome = "mm9",
                     selection = NULL,
                     norm_mode = "fc",
-                    remove_top = 0) {
+                    remove_top = 0,
+                    default_na = NA_real_) {
 
     .validate_filelist(bwfiles)
     norm_func <- .process_norm_mode(norm_mode)
@@ -221,7 +228,8 @@ bw_bins <- function(bwfiles,
             tiles,
             per_locus_stat = per_locus_stat,
             selection = selection,
-            remove_top = remove_top
+            remove_top = remove_top,
+            default_na = default_na
         )
     } else {
         result <- .multi_bw_ranges_norm(
@@ -232,7 +240,8 @@ bw_bins <- function(bwfiles,
             per_locus_stat = per_locus_stat,
             selection = selection,
             norm_func = norm_func,
-            remove_top = remove_top
+            remove_top = remove_top,
+            default_na = default_na
         )
     }
     result
@@ -290,7 +299,8 @@ bw_heatmap <- function(bwfiles,
                         downstream = 2500,
                         middle = NULL,
                         ignore_strand = FALSE,
-                        norm_mode = "fc") {
+                        norm_mode = "fc",
+                        default_na = NA_real_) {
 
     .validate_filelist(bwfiles)
     .validate_locus_parameter(loci)
@@ -317,7 +327,8 @@ bw_heatmap <- function(bwfiles,
         middle = middle,
         ignore_strand = ignore_strand,
         norm_func = norm_func,
-        remove_top = 0
+        remove_top = 0,
+        default_na = default_na
     )
 
     if (is.null(bg_bwfiles)) {
@@ -403,7 +414,8 @@ bw_profile <- function(bwfiles,
                         middle = NULL,
                         ignore_strand = FALSE,
                         norm_mode = "fc",
-                        remove_top = 0) {
+                        remove_top = 0,
+                        default_na = NA_real_) {
 
     .validate_filelist(bwfiles)
     .validate_locus_parameter(loci)
@@ -428,7 +440,8 @@ bw_profile <- function(bwfiles,
         middle = middle,
         ignore_strand = ignore_strand,
         norm_func = norm_func,
-        remove_top = remove_top
+        remove_top = remove_top,
+        default_na = default_na
     )
 
     if (is.null(bg_bwfiles)) {
@@ -475,6 +488,7 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
 #'
 #' @param bwfile Path to a single BigWig file to be summarized.
 #' @param granges GRanges object file to be summarized.
+#' @param default_na Default value for missing values
 #' @importFrom rtracklayer BigWigFile
 #' @importFrom IRanges subsetByOverlaps
 #' @importFrom methods getMethod
@@ -484,7 +498,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
 #' @return GRanges with column score.
 .bw_ranges <- function(bwfile, granges,
                         per_locus_stat = "mean",
-                        selection = NULL) {
+                        selection = NULL,
+                        default_na = NA_real_) {
     bw <- .fetch_bigwig(bwfile)
     if (!is.null(bw)) {
         explicit_summary <- getMethod("summary", "BigWigFile")
@@ -492,7 +507,7 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
         if (!is.null(selection)) {
             granges <- subsetByOverlaps(granges, selection)
         }
-        unlist(explicit_summary(bw, granges, type = per_locus_stat))
+        unlist(explicit_summary(bw, granges, type = per_locus_stat, defaultValue = default_na))
     }
 }
 
@@ -511,7 +526,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
 .multi_bw_ranges <- function(bwfiles, labels, granges,
                                 per_locus_stat = "mean",
                                 selection = NULL,
-                                remove_top = 0) {
+                                remove_top = 0,
+                                default_na = NA_real_) {
 
     if (length(bwfiles) != length(labels)) {
         stop("BigWig file list and column names must have the same length.")
@@ -522,7 +538,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
         .bw_ranges,
         granges = granges,
         per_locus_stat = per_locus_stat,
-        selection = selection
+        selection = selection,
+        default_na = default_na
     )
 
     # granges_cbind sorts each element so it's safer to merge and no need to
@@ -550,14 +567,16 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
 .multi_bw_ranges_aggregated <- function(bwfiles, labels, granges,
                                         per_locus_stat,
                                         aggregate_by,
-                                        remove_top) {
+                                        remove_top,
+                                        default_na = NA_real_) {
 
     result <- .multi_bw_ranges(
         bwfiles,
         labels,
         granges = granges,
         per_locus_stat = per_locus_stat,
-        remove_top = remove_top
+        remove_top = remove_top,
+        default_na = default_na
     )
 
     df <- .aggregate_scores(
@@ -591,7 +610,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
                                     per_locus_stat = "mean",
                                     selection = NULL,
                                     norm_func = identity,
-                                    remove_top = 0) {
+                                    remove_top = 0,
+                                    default_na = NA_real_) {
     if (length(bwfilelist) != length(bg_bwfilelist)) {
         stop("Background and signal bwfile lists must have the same length.")
     }
@@ -601,7 +621,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
         labels,
         granges,
         per_locus_stat = per_locus_stat,
-        selection = selection
+        selection = selection,
+        default_na = default_na
     )
 
     bg <- .multi_bw_ranges(
@@ -609,7 +630,8 @@ build_bins <- function(bin_size = 10000, genome = "mm9") {
         labels,
         granges,
         per_locus_stat = per_locus_stat,
-        selection = selection
+        selection = selection,
+        default_na = default_na
     )
 
     result_df <- data.frame(result)
@@ -722,6 +744,7 @@ utils::globalVariables("where")
 #' @param bg_bw BigWig file to be used as background.
 #' @param label Name to give to the values
 #' @param norm_func Normalization function
+#' @param default_na Default value for missing values
 #' @importFrom rtracklayer BigWigFile import
 #' @importFrom utils download.file
 #' @inheritParams bw_profile
@@ -736,7 +759,8 @@ utils::globalVariables("where")
                                     middle = NULL,
                                     ignore_strand = FALSE,
                                     norm_func = identity,
-                                    remove_top = 0) {
+                                    remove_top = 0,
+                                    default_na = NA_real_) {
     if (is.null(label)) {
         label <- basename(bw)
     }
@@ -751,7 +775,8 @@ utils::globalVariables("where")
         middle = middle,
         ignore_strand = ignore_strand,
         norm_func = identity,
-        remove_top = remove_top
+        remove_top = remove_top,
+        default_na = default_na
     )
 
     fg_sum <- .summarize_matrix(fg, label)
@@ -768,7 +793,8 @@ utils::globalVariables("where")
             middle = middle,
             ignore_strand = ignore_strand,
             norm_func = identity,
-            remove_top = remove_top
+            remove_top = remove_top,
+            default_na = default_na
         )
 
         bg_sum <- .summarize_matrix(bg, "bg")
@@ -800,7 +826,8 @@ utils::globalVariables("where")
                                     middle = NULL,
                                     ignore_strand = FALSE,
                                     norm_func = identity,
-                                    remove_top = 0) {
+                                    remove_top = 0,
+                                    default_na = NA_real_) {
     if (mode == "stretch") {
         full <- .calculate_stretch_matrix(
             bw,
@@ -809,7 +836,8 @@ utils::globalVariables("where")
             upstream = upstream,
             downstream = downstream,
             middle = middle,
-            ignore_strand = ignore_strand
+            ignore_strand = ignore_strand,
+            default_na = default_na
         )
 
         if (!is.null(bg_bw)) {
@@ -819,7 +847,8 @@ utils::globalVariables("where")
                 bin_size = bin_size,
                 upstream = upstream,
                 downstream = downstream,
-                ignore_strand = ignore_strand
+                ignore_strand = ignore_strand,
+                default_na = default_na
             )
 
             full <- norm_func(full / bg)
@@ -837,7 +866,8 @@ utils::globalVariables("where")
             bw,
             granges,
             npoints = npoints,
-            ignore_strand = FALSE
+            ignore_strand = FALSE,
+            default_na = default_na
         )
 
         if (!is.null(bg_bw)) {
@@ -845,7 +875,8 @@ utils::globalVariables("where")
                 bg_bw,
                 granges,
                 npoints = npoints,
-                ignore_strand = FALSE
+                ignore_strand = FALSE,
+                default_na = default_na
             )
 
             full <- norm_func(full / bg)
@@ -869,6 +900,7 @@ utils::globalVariables("where")
 #' @param bin_size Bin size
 #' @param upstream Number of basepairs upstream
 #' @param downstream Number of basepairs downstream
+#' @param default_na Default value for missing values
 #' @param middle Number of base pairs that the middle section has. If not
 #'   provided, median is used.
 #' @param ignore_strand Ignore strand (bool)
@@ -880,7 +912,8 @@ utils::globalVariables("where")
                                         upstream = 2500,
                                         downstream = 2500,
                                         middle = NULL,
-                                        ignore_strand = FALSE) {
+                                        ignore_strand = FALSE,
+                                        default_na = NA_real_) {
 
     left_npoints <- floor(upstream / bin_size)
     right_npoints <- floor(downstream / bin_size)
@@ -896,21 +929,24 @@ utils::globalVariables("where")
         bw,
         flank(granges, upstream, start = TRUE),
         npoints = left_npoints,
-        ignore_strand = ignore_strand
+        ignore_strand = ignore_strand,
+        default_na = default_na
     )
 
     right <- .intersect_bw_and_granges(
         bw,
        flank(granges, downstream, start = FALSE),
        npoints = right_npoints,
-       ignore_strand = ignore_strand
+       ignore_strand = ignore_strand,
+       default_na = default_na
     )
 
     middle <- .intersect_bw_and_granges(
         bw,
         granges,
         npoints = middle_npoints,
-        ignore_strand = ignore_strand
+        ignore_strand = ignore_strand,
+        default_na = default_na
     )
 
     cbind(left, middle, right)
@@ -926,13 +962,15 @@ utils::globalVariables("where")
 #' @param granges GRanges object.
 #' @param npoints How many points to take (different to bin size!).
 #' @param ignore_strand Ignore strand information in granges.
+#' @param default_na Value to use as default for missing values
 #' @importFrom rtracklayer summary
 #' @importFrom GenomicRanges strand
 #' @return A value matrix of dimensions len(granges) x npoints.
 .intersect_bw_and_granges <- function(bw, granges, npoints,
-                                        ignore_strand = FALSE) {
+                                        ignore_strand = FALSE,
+                                      default_na = NA_real_) {
     bwfile <- .fetch_bigwig(bw)
-    values <- summary(bwfile, which = granges, as = "matrix", size = npoints)
+    values <- summary(bwfile, which = granges, as = "matrix", size = npoints, defaultValue = default_na)
 
     # Reverse minus strand rows
     if (!ignore_strand) {

--- a/man/bw_bins.Rd
+++ b/man/bw_bins.Rd
@@ -13,7 +13,8 @@ bw_bins(
   genome = "mm9",
   selection = NULL,
   norm_mode = "fc",
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A GRanges object with each bwfile as a metadata column named

--- a/man/bw_heatmap.Rd
+++ b/man/bw_heatmap.Rd
@@ -15,7 +15,8 @@ bw_heatmap(
   downstream = 2500,
   middle = NULL,
   ignore_strand = FALSE,
-  norm_mode = "fc"
+  norm_mode = "fc",
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -53,6 +54,8 @@ mode). If not provided, median length of all loci is used.}
 
 \item{norm_mode}{Function to apply to normalize bin values. Default fc:
 divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A list of matrices where each element correspond to each bigWig file.

--- a/man/bw_loci.Rd
+++ b/man/bw_loci.Rd
@@ -12,7 +12,8 @@ bw_loci(
   per_locus_stat = "mean",
   aggregate_by = NULL,
   norm_mode = "fc",
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -37,6 +38,8 @@ divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A GRanges object with each bwfile as a metadata column named

--- a/man/bw_profile.Rd
+++ b/man/bw_profile.Rd
@@ -16,7 +16,8 @@ bw_profile(
   middle = NULL,
   ignore_strand = FALSE,
   norm_mode = "fc",
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -57,6 +58,8 @@ divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 a data frame in long format

--- a/man/dot-aggregate_scores.Rd
+++ b/man/dot-aggregate_scores.Rd
@@ -11,14 +11,16 @@
 
 \item{group_col}{A column among the mcols that can be seen as a factor.}
 
-\item{aggregate_by}{Function used to aggregate: mean, median, true_mean.\preformatted{true_mean: Mean coverage taking all elements in a class as one large bin.
+\item{aggregate_by}{Function used to aggregate: mean, median, true_mean.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{true_mean: Mean coverage taking all elements in a class as one large bin.
 
 mean: mean-of-distribution approach. The mean of the aggregated value per
   locus is reported.
 
 median: median-of-distribution. The median of the aggregated value per
   locus is reported.
-}
+}\if{html}{\out{</div>}}
 
 This does not pass the checks but does not break the build process either
 so I left it as is, so the note thrown by build is noted everytime.}

--- a/man/dot-bw_ranges.Rd
+++ b/man/dot-bw_ranges.Rd
@@ -4,7 +4,13 @@
 \alias{.bw_ranges}
 \title{Score a GRanges object against a BigWig file}
 \usage{
-.bw_ranges(bwfile, granges, per_locus_stat = "mean", selection = NULL)
+.bw_ranges(
+  bwfile,
+  granges,
+  per_locus_stat = "mean",
+  selection = NULL,
+  default_na = NA_real_
+)
 }
 \arguments{
 \item{bwfile}{Path to a single BigWig file to be summarized.}
@@ -17,6 +23,8 @@ Choices: min, max, sd, mean.}
 \item{selection}{A GRanges object to restrict binning to a certain set of
 intervals. This is useful for debugging and improving performance of
 locus specific analyses.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 GRanges with column score.

--- a/man/dot-calculate_bw_profile.Rd
+++ b/man/dot-calculate_bw_profile.Rd
@@ -16,7 +16,8 @@
   middle = NULL,
   ignore_strand = FALSE,
   norm_func = identity,
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -54,6 +55,8 @@ mode). If not provided, median length of all loci is used.}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A DataFrame with the aggregated scores

--- a/man/dot-calculate_matrix_norm.Rd
+++ b/man/dot-calculate_matrix_norm.Rd
@@ -15,7 +15,8 @@
   middle = NULL,
   ignore_strand = FALSE,
   norm_func = identity,
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -51,6 +52,8 @@ mode). If not provided, median length of all loci is used.}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 Summary matrix

--- a/man/dot-calculate_stretch_matrix.Rd
+++ b/man/dot-calculate_stretch_matrix.Rd
@@ -11,7 +11,8 @@
   upstream = 2500,
   downstream = 2500,
   middle = NULL,
-  ignore_strand = FALSE
+  ignore_strand = FALSE,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -29,6 +30,8 @@
 provided, median is used.}
 
 \item{ignore_strand}{Ignore strand (bool)}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 Summary matrix

--- a/man/dot-intersect_bw_and_granges.Rd
+++ b/man/dot-intersect_bw_and_granges.Rd
@@ -4,7 +4,13 @@
 \alias{.intersect_bw_and_granges}
 \title{Intersect a BigWig file over loci on a GRanges object}
 \usage{
-.intersect_bw_and_granges(bw, granges, npoints, ignore_strand = FALSE)
+.intersect_bw_and_granges(
+  bw,
+  granges,
+  npoints,
+  ignore_strand = FALSE,
+  default_na = NA_real_
+)
 }
 \arguments{
 \item{bw}{BigWigFile object (rtracklayer).}
@@ -14,6 +20,8 @@
 \item{npoints}{How many points to take (different to bin size!).}
 
 \item{ignore_strand}{Ignore strand information in granges.}
+
+\item{default_na}{Value to use as default for missing values}
 }
 \value{
 A value matrix of dimensions len(granges) x npoints.

--- a/man/dot-multi_bw_ranges.Rd
+++ b/man/dot-multi_bw_ranges.Rd
@@ -10,7 +10,8 @@
   granges,
   per_locus_stat = "mean",
   selection = NULL,
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ locus specific analyses.}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A sorted GRanges object.

--- a/man/dot-multi_bw_ranges_aggregated.Rd
+++ b/man/dot-multi_bw_ranges_aggregated.Rd
@@ -10,7 +10,8 @@
   granges,
   per_locus_stat,
   aggregate_by,
-  remove_top
+  remove_top,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ not aggregated. This is the behavior by default.}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 An aggregated dataframe

--- a/man/dot-multi_bw_ranges_norm.Rd
+++ b/man/dot-multi_bw_ranges_norm.Rd
@@ -12,7 +12,8 @@
   per_locus_stat = "mean",
   selection = NULL,
   norm_func = identity,
-  remove_top = 0
+  remove_top = 0,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ Choices: min, max, sd, mean.}
 
 \item{remove_top}{Return range 0-(1-remove_top). By default returns the
 whole distribution (remove_top == 0).}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 a sorted GRanges object

--- a/man/plot_bw_bins_violin.Rd
+++ b/man/plot_bw_bins_violin.Rd
@@ -18,7 +18,8 @@ plot_bw_bins_violin(
   highlight_colors = NULL,
   remove_top = 0,
   verbose = TRUE,
-  selection = NULL
+  selection = NULL,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -56,6 +57,8 @@ whole distribution (remove_top == 0).}
 \item{selection}{A GRanges object to restrict binning to a certain set of
 intervals. This is useful for debugging and improving performance of
 locus specific analyses.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A ggplot object.

--- a/man/plot_bw_heatmap.Rd
+++ b/man/plot_bw_heatmap.Rd
@@ -20,7 +20,8 @@ plot_bw_heatmap(
   zmax = NULL,
   max_rows_allowed = 10000,
   order_by = NULL,
-  verbose = TRUE
+  verbose = TRUE,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -76,6 +77,8 @@ length as number of rows. These can be obtained as a result of order()
 function, if one would want to sort one heatmap by values on another one.}
 
 \item{verbose}{Put a caption with relevant parameters on the plot.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A ggplot object

--- a/man/plot_bw_loci_scatter.Rd
+++ b/man/plot_bw_loci_scatter.Rd
@@ -17,7 +17,8 @@ plot_bw_loci_scatter(
   highlight_label = NULL,
   highlight_colors = NULL,
   remove_top = 0,
-  verbose = TRUE
+  verbose = TRUE,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -49,6 +50,8 @@ whole distribution (remove_top == 0).}
 
 \item{verbose}{Verbose plot. Returns a plot with all relevant parameters in
 a caption.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A ggplot object.

--- a/man/plot_bw_loci_summary_heatmap.Rd
+++ b/man/plot_bw_loci_summary_heatmap.Rd
@@ -12,7 +12,8 @@ plot_bw_loci_summary_heatmap(
   aggregate_by = "true_mean",
   norm_mode = "fc",
   remove_top = 0,
-  verbose = TRUE
+  verbose = TRUE,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -35,6 +36,8 @@ divides bw / bg. Alternative: log2fc: returns log2(bw/bg).}
 whole distribution (remove_top == 0).}
 
 \item{verbose}{Put a caption with relevant parameters on the plot.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A ggplot object

--- a/man/plot_bw_profile.Rd
+++ b/man/plot_bw_profile.Rd
@@ -19,7 +19,8 @@ plot_bw_profile(
   labels = NULL,
   colors = NULL,
   remove_top = 0,
-  verbose = TRUE
+  verbose = TRUE,
+  default_na = NA_real_
 )
 }
 \arguments{
@@ -67,6 +68,8 @@ object. If NULL, file names are used.}
 whole distribution (remove_top == 0).}
 
 \item{verbose}{Put a caption with relevant parameters on the plot.}
+
+\item{default_na}{Default value for missing values}
 }
 \value{
 A ggplot object.

--- a/tests/testthat/test-bwtools.R
+++ b/tests/testthat/test-bwtools.R
@@ -505,6 +505,26 @@ test_that("bw_loci excludes NA values from single locus", {
 })
 
 
+test_that("bw_loci with default_na = 0 does NOT include NA values in mean calculation for single locus", {
+    # NOTE: This test is here as documentation of somewhat counterintuitive
+    # behavior: We could expect rtracklayer summary function to actually include
+    # values in mean calculation if a different defaultValue to NA is used, but it
+    # is not true. It still counts only the part of the sequence that has values,
+    # excluding missing values from the length of the locus, which means the result
+    # for a single loci is the same whether default_na is 0 or NA. default_na is
+    # only presented when the FULL locus is empty (and a warning is also printed)
+
+    # Here, a locus 21-50 that has NA on 21-40 and 3 on 41-50 STILL
+    # yields a mean of 3.
+    values <- suppressWarnings(bw_loci(bw4_nas, bed_with_names_na,
+                                       labels = "bw4_nas",
+                                       per_locus_stat = "mean",
+                                       default_na = 0)
+    )
+    expect_equal(values[1]$bw4_nas, 3)
+})
+
+
 test_that("bw_loci fails if aggregate_by in an unnamed bed file", {
   expect_error({
     values <- bw_loci(bw1, unnamed_bed, bg_bwfiles = bw2,


### PR DESCRIPTION
Added a `default_na` parameter to all relevant functions. Its default value is the previous behavior, so NA values are inserted whenever values are missing. However it is now possible to replace them for instance with a 0 value.

NOTE that if a locus or bin only partially overlaps with NA values, these are excluded from mean calculation, but not replaced by `default_na`. This is due to `rtracklayer` function underneath. A test function is added to `test_bwtools.R` to state this behavior.