### PR TITLE
Fix peak import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wigglescout
 Title: Explore and Visualize Genomics BigWig Data
-Version: 0.16.0
+Version: 0.16.1
 Authors@R: 
     person(given = "Carmen",
            family = "Navarro",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# wigglescout 0.16.1
+
+## Bug fixes
+
+* Fixed issue importing formats different to BED files. Now the format guessing
+is left to rtracklayer and narrowPeak files are accepted. Fixes issue #98.
+
 # wigglescout 0.16.0
 
 ## Features

--- a/R/utils.R
+++ b/R/utils.R
@@ -259,7 +259,7 @@
 #' @return An integer
 .loci_length <- function(loci) {
     if (is.character(loci)) {
-        length(rtracklayer::import(loci, format="BED"))
+        length(rtracklayer::import(loci))
     } else {
         length(loci)
     }
@@ -277,7 +277,7 @@
 .loci_to_granges <- function(loci) {
     bed <- loci
     if (is(loci, "character")){
-        bed <- import(loci, format = "BED")
+        bed <- import(loci)
     }
     if ("name" %in% names(mcols(bed))) {
         bed <- bed[, "name"]


### PR DESCRIPTION
Now `rtracklayer::import` is always called agnostic of file format since it does guess it under the hood. 

This fixes #98.