### PR TITLE
Update r-cmd-check.yml

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -17,6 +17,7 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:


### PR DESCRIPTION
Mini PR to fix the codecov integration - Apparently in the past couple years they have added tokens for public repos as well.